### PR TITLE
Update test matrix to use macOS 13 + Xcode 14.3.1 and macOS 14 + Xcode 15.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,15 +15,9 @@ jobs:
       matrix:
         include:
         - macos: macOS-13
-          xcode: "14.3"
-        - macos: macOS-12
-          xcode: "14.1"
-        - macos: macOS-12
-          xcode: "13.4.1"
-        - macos: macOS-11
-          xcode: "13.1"
-        - macos: macOS-11
-          xcode: "12.5"
+          xcode: "14.3.1"
+        - macos: macOS-14
+          xcode: "15.4"
     env:
       BUNDLE_JOBS: 4
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer

--- a/Formula/xcnew.rb
+++ b/Formula/xcnew.rb
@@ -12,8 +12,8 @@ class Xcnew < Formula
   end
 
   test do
-    assert_predicate man1/"xcnew.1", :exist?
+    assert_path_exists man1/"xcnew.1"
     system bin/"xcnew", "Example", testpath/"Example"
-    assert_predicate testpath/"Example/Example.xcodeproj/project.pbxproj", :exist?
+    assert_path_exists testpath/"Example/Example.xcodeproj/project.pbxproj"
   end
 end


### PR DESCRIPTION
This PR updates the test matrix configuration to run tests on the following environments:

- macOS 13 (Ventura) with Xcode 14.3.1
- macOS 14 (Sonoma) with Xcode 15.4

This change ensures that we test our formulas against both the previous stable and the latest versions of macOS and Xcode.